### PR TITLE
Added COOP and CORP policies. Added a more open COEP to allow for the use of GCDS

### DIFF
--- a/GCFoundation.Security/Middlewares/GCFoundationContentPoliciesMiddleware.cs
+++ b/GCFoundation.Security/Middlewares/GCFoundationContentPoliciesMiddleware.cs
@@ -58,8 +58,8 @@ namespace GCFoundation.Security.Middlewares
             // COEP "credentialless" allows cross-origin resources (e.g. GCDS CSS from cdn.design-system.alpha.canada.ca)
             // to load without requiring CORP/CORS from the CDN, while still isolating them (no credentials sent).
             // "require-corp" would block GCDS/CDN styles unless the CDN sends Cross-Origin-Resource-Policy.
-            context.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-site");
-            context.Response.Headers.Append("Cross-Origin-Resource-Policy", "same-site");
+            context.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-origin");
+            context.Response.Headers.Append("Cross-Origin-Resource-Policy", "same-origin");
             context.Response.Headers.Append("Cross-Origin-Embedder-Policy", "credentialless");
 
             await _next(context).ConfigureAwait(false);


### PR DESCRIPTION
Closes #86

As recommended, added same-origin values to the COOP and CORP policies. Adding "require-corp" to the CORP was preventing GCDS stylesheets from loading. COEP "credentialless" allows cross-origin resources (e.g. GCDS CSS from cdn.design-system.alpha.canada.ca) to load without requiring CORP/CORS from the CDN, while still isolating them (no credentials sent). "require-corp" would block GCDS/CDN styles unless the CDN sends Cross-Origin-Resource-Policy.