### PR TITLE
Changes to the CSP settings to allow the definitions of img-src and frame-src.

### DIFF
--- a/GCFoundation.Common/Settings/GCFoundationContentPolicySettings.cs
+++ b/GCFoundation.Common/Settings/GCFoundationContentPolicySettings.cs
@@ -11,34 +11,46 @@
         /// These will be added to the 'connect-src' directive in the CSP header.
         /// Example: "https://cdn.design-system.alpha.canada.ca"
         /// </summary>
-        public IEnumerable<string> ConnectCDN { get; set; } = Enumerable.Empty<string>();
-
-        /// <summary>
-        /// Gets or sets the list of CSS CDN hosts that are allowed to load stylesheets.
-        /// These will be added to the 'style-src' directive in the CSP header.
-        /// Example: "https://fonts.googleapis.com"
-        /// </summary>
-        public IEnumerable<string> CssCDN { get; set; } = Enumerable.Empty<string>();
-
-        /// <summary>
-        /// Gets or sets the list of SHA-256 hashes that allow specific inline styles.
-        /// These hashes will also be added to the 'style-src' directive to support safe inline styles.
-        /// Example: "'sha256-AbCdEf123=='"
-        /// </summary>
-        public IEnumerable<string> CssCDNHash { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> ConnectSrc { get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// Gets or sets the list of font CDN hosts that are allowed to load fonts.
         /// These will be added to the 'font-src' directive in the CSP header.
         /// Example: "https://fonts.gstatic.com"
         /// </summary>
-        public IEnumerable<string> FontCDN { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> FontSrc { get; set; } = Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the list of hosts that are allowed to load frames.
+        /// These will be added to the 'frame-src' directive in the CSP header.
+        /// </summary>
+        public IEnumerable<string> FrameSrc { get; set; } = Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the list of hosts that are allowed to load images.
+        /// These will be added to the 'img-src' directive in the CSP header.
+        /// </summary>
+        public IEnumerable<string> ImgSrc { get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// Gets or sets the list of JavaScript CDN hosts that are allowed to load scripts.
         /// These will be added to the 'script-src' directive in the CSP header.
         /// Example: "https://cdn.jsdelivr.net"
         /// </summary>
-        public IEnumerable<string> JavascriptCDN { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> ScriptSrc { get; set; } = Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the list of CSS CDN hosts that are allowed to load stylesheets.
+        /// These will be added to the 'style-src' directive in the CSP header.
+        /// Example: "https://fonts.googleapis.com"
+        /// </summary>
+        public IEnumerable<string> StyleSrc { get; set; } = Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the list of SHA-256 hashes that allow specific inline styles.
+        /// These hashes will also be added to the 'style-src' directive to support safe inline styles.
+        /// Example: "'sha256-AbCdEf123=='"
+        /// </summary>
+        public IEnumerable<string> StyleSrcHash { get; set; } = Enumerable.Empty<string>();
     }
 }

--- a/GCFoundation.Components/Configuration/FoundationComponentsCdnPolicyConfigurator.cs
+++ b/GCFoundation.Components/Configuration/FoundationComponentsCdnPolicyConfigurator.cs
@@ -66,11 +66,11 @@ namespace GCFoundation.Components.Configuration
                 }
             }
 
-            options.JavascriptCDN = jsCDNs;
-            options.CssCDN = cssCDNs;
-            options.CssCDNHash = cssHashes;
-            options.FontCDN = fontCDNs;
-            options.ConnectCDN = connectCDNs;
+            options.ConnectSrc = connectCDNs;
+            options.FontSrc = fontCDNs;
+            options.ScriptSrc = jsCDNs;
+            options.StyleSrc = cssCDNs;
+            options.StyleSrcHash = cssHashes;
         }
     }
 }

--- a/GCFoundation.Security/Middlewares/GCFoundationContentPoliciesMiddleware.cs
+++ b/GCFoundation.Security/Middlewares/GCFoundationContentPoliciesMiddleware.cs
@@ -30,22 +30,24 @@ namespace GCFoundation.Security.Middlewares
             context.Items["CspNonce"] = nonce; // Store for use in views (if required)
 
             // Convert lists to space-separated strings
-            string connectCDN = string.Join(" ", _settings.ConnectCDN ?? Enumerable.Empty<string>());
-            string cssCDN = string.Join(" ", _settings.CssCDN ?? Enumerable.Empty<string>());
-            string cssCDNHash = string.Join(" ", _settings.CssCDNHash ?? Enumerable.Empty<string>());
-            string fontCDN = string.Join(" ", _settings.FontCDN ?? Enumerable.Empty<string>());
-            string jsCDN = string.Join(" ", _settings.JavascriptCDN ?? Enumerable.Empty<string>());
+            string connectSrc = string.Join(" ", _settings.ConnectSrc ?? Enumerable.Empty<string>());
+            string fontSrc = string.Join(" ", _settings.FontSrc ?? Enumerable.Empty<string>());
+            string frameSrc = string.Join(" ", _settings.FrameSrc ?? Enumerable.Empty<string>());
+            string imgSrc = string.Join(" ", _settings.ImgSrc ?? Enumerable.Empty<string>());
+            string scriptSrc = string.Join(" ", _settings.ScriptSrc ?? Enumerable.Empty<string>());
+            string styleSrc = string.Join(" ", _settings.StyleSrc ?? Enumerable.Empty<string>());
+            string styleSrcHash = string.Join(" ", _settings.StyleSrcHash ?? Enumerable.Empty<string>());
 
             // Build Content Security Policy (CSP)
             // * If Adobe Analytics is enabled, accept "unsafe-inline" for "script-src"; otherwise, generate and set a "nonce".
             string contentSecurityPolicy = $"default-src 'none'; " +
-                               $"script-src 'self' {jsCDN} {(_componentsSettings.IncludeAdobeAnalytics ? "'unsafe-inline'" : $"'nonce-{nonce}'")}; " +
+                               $"script-src 'self' {scriptSrc} {(_componentsSettings.IncludeAdobeAnalytics ? "'unsafe-inline'" : $"'nonce-{nonce}'")}; " +
                                $"object-src 'none'; " +
-                               $"style-src 'self' 'unsafe-hashes' {cssCDN} {cssCDNHash} 'nonce-{nonce}'; " +
-                               $"font-src 'self' {fontCDN}; " +
-                               $"connect-src 'self' {connectCDN} http://localhost:* https://localhost:* ws://localhost:* wss://localhost:* https://cdn.design-system.alpha.canada.ca; " +
-                               $"img-src 'self' {(_componentsSettings.IncludeAdobeAnalytics ? "https://cm.everesttech.net https://canada.sc.omtrdc.net" : string.Empty)} data:; " +
-                               (_componentsSettings.IncludeAdobeAnalytics ? $"frame-src 'self' https://canada.demdex.net; " : string.Empty) +
+                               $"style-src 'self' 'unsafe-hashes' {styleSrc} {styleSrcHash} 'nonce-{nonce}'; " +
+                               $"font-src 'self' {fontSrc}; " +
+                               $"connect-src 'self' {connectSrc} http://localhost:* https://localhost:* ws://localhost:* wss://localhost:* https://cdn.design-system.alpha.canada.ca; " +
+                               $"img-src 'self' {imgSrc} data:; " +
+                               $"frame-src 'self' {frameSrc}; " +
                                $"frame-ancestors 'none'; " +
                                $"upgrade-insecure-requests;";
 

--- a/GCFoundation.Web/appsettings.json
+++ b/GCFoundation.Web/appsettings.json
@@ -62,18 +62,18 @@
     ]
   },
   "ContentPolicySettings": {
-    "JavascriptCDN": [
+    "FontSrc": [
+      "https://fonts.gstatic.com"
+    ],
+    "ScriptSrc": [
       "https://cdn.jsdelivr.net",
       "https://code.jquery.com/"
     ],
-    "CssCDN": [
+    "StyleSrc": [
       "https://cdn.jsdelivr.net",
       "https://fonts.googleapis.com"
     ],
-    "FontCDN": [
-      "https://fonts.gstatic.com"
-    ],
-    "CssCDNHash": [
+    "StyleSrcHash": [
       "'sha256-q5rmgt0qnS6vusTX681CxP1llW8fGLSs67L4+dVXYgM='",
       "'sha256-ks7E/72keU8WISNCPrcvCse2IFBOPIKwQdjS6pVCE1Y='",
       "'sha256-ERcMBQCTSFQZVLkMDfpCJdTJlTBIXUd4n/r9Xvw8QVQ='"


### PR DESCRIPTION
In this case more specifically to allow for the proper configuration of Adobe Analytics.

Change to the appsettings of the GCFoundation.Web to accomodate the new changes to the CSP settings.