### PR TITLE
Accessibility statement/Footer links adjustments.

### DIFF
--- a/GCFoundation.Components/TagHelpers/GCDS/FooterTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/FooterTagHelper.cs
@@ -1,6 +1,10 @@
-﻿using GCFoundation.Common.Utilities;
+﻿using GCFoundation.Common.Models;
+using GCFoundation.Common.Utilities;
 using GCFoundation.Components.Enums;
-using GCFoundation.Common.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Text.Json;
 
@@ -11,8 +15,14 @@ namespace GCFoundation.Components.TagHelpers.GCDS
     /// This tag helper generates a footer with support for customizable headings, links, and display options.
     /// </summary>
     [HtmlTargetElement("gcds-footer")]
-    public class FooterTagHelper : BaseTagHelper
+    public class FooterTagHelper(IUrlHelperFactory urlHelperFactory) : BaseTagHelper
     {
+        private readonly IUrlHelperFactory UrlHelperFactory = urlHelperFactory;
+
+        [ViewContext]
+        [HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
+
         /// <summary>
         /// The optional heading text to display in the footer's contextual section.
         /// </summary>
@@ -38,15 +48,17 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <inheritdoc/>
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
+            var urlHelper = UrlHelperFactory.GetUrlHelper(ViewContext);
+
             AddAttributeIfNotNull(output, "contextual-heading", ContextualHeading);
 
-            if (SerializeFooterLinksDictionary(ContextualLinks) is { } contextualLinksJson)
+            if (SerializeFooterLinksDictionary(ContextualLinks, urlHelper) is { } contextualLinksJson)
                 output.Attributes.SetAttribute("contextual-links", contextualLinksJson);
 
             AddAttributeIfNotNull(output, "display", Display);
             AddAttributeIfNotNull(output, "lang", Lang);
 
-            if (SerializeFooterLinksDictionary(SubLinks) is { } subLinksJson)
+            if (SerializeFooterLinksDictionary(SubLinks, urlHelper) is { } subLinksJson)
                 output.Attributes.SetAttribute("sub-links", subLinksJson);
 
             base.Process(context, output);
@@ -55,13 +67,13 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Builds a JSON object keyed by localized label for the GCDS footer attribute, or <c>null</c> when there is nothing to emit.
         /// </summary>
-        private static string? SerializeFooterLinksDictionary(IEnumerable<FooterLink>? links)
+        private static string? SerializeFooterLinksDictionary(IEnumerable<FooterLink>? links, IUrlHelper urlHelper)
         {
             if (links is null)
                 return null;
 
             var pairs = links
-                .Select(link => (Label: link.GetLocalizedLabel(), Link: link.GetLocalizedLink()))
+                .Select(link => (Label: link.GetLocalizedLabel(), Link: urlHelper.Content(link.GetLocalizedLink())))
                 .Where(pair => !string.IsNullOrWhiteSpace(pair.Label) && !string.IsNullOrWhiteSpace(pair.Link))
                 .ToList();
 

--- a/GCFoundation.Tests.Components/Tests/Settings/GCFoundationComponentsGlobalFooterLinksTests.cs
+++ b/GCFoundation.Tests.Components/Tests/Settings/GCFoundationComponentsGlobalFooterLinksTests.cs
@@ -1,0 +1,103 @@
+using GCFoundation.Common.Settings;
+using Microsoft.Extensions.Configuration;
+using System.Text;
+
+namespace GCFoundation.Tests.Components.Tests.Settings
+{
+    /// <summary>
+    /// Verifies <see cref="GCFoundationComponentsSettings.GlobalFooterContextualLinks"/> and
+    /// <see cref="GCFoundationComponentsSettings.GlobalFooterSubLinks"/> bind from JSON configuration
+    /// with absolute (<c>https://</c>), site-relative (<c>/</c>), and application-root (<c>~/</c>) URLs.
+    /// </summary>
+    public class GCFoundationComponentsGlobalFooterLinksTests
+    {
+        private const string SampleJson =
+            """
+            {
+              "FoundationComponentsSettings": {
+                "GlobalFooterContextualLinks": [
+                  {
+                    "label": "External",
+                    "link": "https://example.com/path"
+                  },
+                  {
+                    "label": "Relative",
+                    "link": "/en/home/"
+                  },
+                  {
+                    "label": "App root",
+                    "link": "~/en/home/"
+                  }
+                ],
+                "GlobalFooterSubLinks": [
+                  {
+                    "labelEn": "Sub CDN",
+                    "labelFr": "Sous CDN",
+                    "linkEn": "https://cdn.example.com/asset",
+                    "linkFr": "https://cdn.example.com/asset"
+                  },
+                  {
+                    "labelEn": "Sub relative EN",
+                    "labelFr": "Sous relatif FR",
+                    "linkEn": "/en/other/",
+                    "linkFr": "/fr/autre/"
+                  },
+                  {
+                    "labelEn": "Sub tilde EN",
+                    "labelFr": "Sous tilde FR",
+                    "linkEn": "~/en/pages/x",
+                    "linkFr": "~/fr/pages/x"
+                  }
+                ]
+              }
+            }
+            """;
+
+        [Fact]
+        public void Bind_FromJson_GlobalFooterContextualLinks_PreservesConfiguredUrlShapes()
+        {
+            var settings = BindSettings();
+
+            Assert.Equal(3, settings.GlobalFooterContextualLinks.Count);
+
+            Assert.Equal("External", settings.GlobalFooterContextualLinks[0].Label);
+            Assert.Equal("https://example.com/path", settings.GlobalFooterContextualLinks[0].Link);
+
+            Assert.Equal("Relative", settings.GlobalFooterContextualLinks[1].Label);
+            Assert.Equal("/en/home/", settings.GlobalFooterContextualLinks[1].Link);
+
+            Assert.Equal("App root", settings.GlobalFooterContextualLinks[2].Label);
+            Assert.Equal("~/en/home/", settings.GlobalFooterContextualLinks[2].Link);
+        }
+
+        [Fact]
+        public void Bind_FromJson_GlobalFooterSubLinks_PreservesConfiguredUrlShapes()
+        {
+            var settings = BindSettings();
+
+            Assert.Equal(3, settings.GlobalFooterSubLinks.Count);
+
+            Assert.Equal("https://cdn.example.com/asset", settings.GlobalFooterSubLinks[0].LinkEn);
+            Assert.Equal("https://cdn.example.com/asset", settings.GlobalFooterSubLinks[0].LinkFr);
+
+            Assert.Equal("/en/other/", settings.GlobalFooterSubLinks[1].LinkEn);
+            Assert.Equal("/fr/autre/", settings.GlobalFooterSubLinks[1].LinkFr);
+
+            Assert.Equal("~/en/pages/x", settings.GlobalFooterSubLinks[2].LinkEn);
+            Assert.Equal("~/fr/pages/x", settings.GlobalFooterSubLinks[2].LinkFr);
+        }
+
+        private static GCFoundationComponentsSettings BindSettings()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SampleJson));
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(stream)
+                .Build();
+
+            var settings = configuration.GetSection("FoundationComponentsSettings").Get<GCFoundationComponentsSettings>();
+
+            Assert.NotNull(settings);
+            return settings;
+        }
+    }
+}

--- a/GCFoundation.Tests.Components/Tests/TagHelpers/GCDS/FooterTagHelperTests.cs
+++ b/GCFoundation.Tests.Components/Tests/TagHelpers/GCDS/FooterTagHelperTests.cs
@@ -1,0 +1,179 @@
+using GCFoundation.Common.Models;
+using GCFoundation.Components.TagHelpers.GCDS;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using System.Globalization;
+using System.Text.Json;
+
+namespace GCFoundation.Tests.Components.Tests.TagHelpers.GCDS
+{
+    /// <summary>
+    /// Verifies footer link URLs after <see cref="Microsoft.AspNetCore.Mvc.IUrlHelper.Content"/> resolution
+    /// for absolute, site-relative, and application-root (<c>~/</c>) paths configured on contextual and sub-links.
+    /// </summary>
+    public class FooterTagHelperTests
+    {
+        [Fact]
+        public void Process_ContextualLinks_AbsoluteUri_PassesThroughUnchanged()
+        {
+            const string href = "https://github.com/tbs-imtd/GCFoundation";
+            using var _ = new CultureScope("en-CA");
+            var output = RunProcess(
+                PathString.Empty,
+                contextualLinks: [new FooterLink { Label = "Repo", Link = href }]);
+
+            var json = GetJsonAttribute(output, "contextual-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal(href, doc.RootElement.GetProperty("Repo").GetString());
+        }
+
+        [Fact]
+        public void Process_ContextualLinks_SiteRelativePath_PassesThroughUnchanged()
+        {
+            const string href = "/en/home/accessibility-statement";
+            using var _ = new CultureScope("en-CA");
+            var output = RunProcess(
+                PathString.Empty,
+                contextualLinks: [new FooterLink { Label = "Accessibility", Link = href }]);
+
+            var json = GetJsonAttribute(output, "contextual-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal(href, doc.RootElement.GetProperty("Accessibility").GetString());
+        }
+
+        [Fact]
+        public void Process_ContextualLinks_ApplicationRelativeTilde_ResolvesPathBase()
+        {
+            const string configured = "~/en/home/";
+            const string pathBase = "/myapp";
+            using var _ = new CultureScope("en-CA");
+            var output = RunProcess(
+                new PathString(pathBase),
+                contextualLinks: [new FooterLink { Label = "Home", Link = configured }]);
+
+            var json = GetJsonAttribute(output, "contextual-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal($"{pathBase}/en/home/", doc.RootElement.GetProperty("Home").GetString());
+        }
+
+        [Fact]
+        public void Process_SubLinks_AbsoluteUri_PassesThroughUnchanged()
+        {
+            const string href = "https://www.canada.ca/en.html";
+            using var _ = new CultureScope("fr-CA");
+            var output = RunProcess(
+                PathString.Empty,
+                subLinks: [new FooterLink { Label = "Canada", LabelFr = "Canada", Link = href, LinkFr = href }]);
+
+            var json = GetJsonAttribute(output, "sub-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal(href, doc.RootElement.GetProperty("Canada").GetString());
+        }
+
+        [Fact]
+        public void Process_SubLinks_SiteRelativePath_PassesThroughUnchanged()
+        {
+            const string href = "/fr/accueil/";
+            using var _ = new CultureScope("fr-CA");
+            var output = RunProcess(
+                PathString.Empty,
+                subLinks: [new FooterLink { Label = "Accueil", LinkFr = href }]);
+
+            var json = GetJsonAttribute(output, "sub-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal(href, doc.RootElement.GetProperty("Accueil").GetString());
+        }
+
+        [Fact]
+        public void Process_SubLinks_ApplicationRelativeTilde_ResolvesPathBase()
+        {
+            const string configured = "~/fr/accueil/";
+            const string pathBase = "/virtual";
+            using var _ = new CultureScope("fr-CA");
+            var output = RunProcess(
+                new PathString(pathBase),
+                subLinks: [new FooterLink { LabelFr = "Accueil", LinkFr = configured }]);
+
+            var json = GetJsonAttribute(output, "sub-links");
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal($"{pathBase}/fr/accueil/", doc.RootElement.GetProperty("Accueil").GetString());
+        }
+
+        private static TagHelperOutput RunProcess(
+            PathString pathBase,
+            IEnumerable<FooterLink>? contextualLinks = null,
+            IEnumerable<FooterLink>? subLinks = null)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.PathBase = pathBase;
+
+            var actionContext = new ActionContext(
+                httpContext,
+                new RouteData(),
+                new ActionDescriptor());
+
+            var viewContext = new ViewContext(
+                actionContext,
+                Mock.Of<IView>(),
+                new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
+                new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>()),
+                TextWriter.Null,
+                new HtmlHelperOptions());
+
+            var helper = new FooterTagHelper(new UrlHelperFactory())
+            {
+                ViewContext = viewContext,
+                ContextualLinks = contextualLinks,
+                SubLinks = subLinks
+            };
+
+            var output = new TagHelperOutput(
+                "gcds-footer",
+                new TagHelperAttributeList(),
+                (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+            helper.Process(CreateContext(), output);
+            return output;
+        }
+
+        private static string GetJsonAttribute(TagHelperOutput output, string name)
+        {
+            var attr = output.Attributes.FirstOrDefault(a => a.Name == name);
+            Assert.NotNull(attr);
+            return attr.Value?.ToString() ?? throw new InvalidOperationException($"Missing {name} value.");
+        }
+
+        private static TagHelperContext CreateContext() =>
+            new(new TagHelperAttributeList(), new Dictionary<object, object>(), "test-id");
+
+        private sealed class CultureScope : IDisposable
+        {
+            private readonly CultureInfo _previousCulture;
+            private readonly CultureInfo _previousUiCulture;
+
+            public CultureScope(string cultureName)
+            {
+                _previousCulture = CultureInfo.CurrentCulture;
+                _previousUiCulture = CultureInfo.CurrentUICulture;
+                var culture = CultureInfo.GetCultureInfo(cultureName);
+                CultureInfo.CurrentCulture = culture;
+                CultureInfo.CurrentUICulture = culture;
+            }
+
+            public void Dispose()
+            {
+                CultureInfo.CurrentCulture = _previousCulture;
+                CultureInfo.CurrentUICulture = _previousUiCulture;
+            }
+        }
+    }
+}

--- a/GCFoundation.Web/Resources/Navigation.Designer.cs
+++ b/GCFoundation.Web/Resources/Navigation.Designer.cs
@@ -250,6 +250,15 @@ namespace GCFoundation.Web.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Accessibility statement.
+        /// </summary>
+        public static string Nav_Home_AccessibilityStatement {
+            get {
+                return ResourceManager.GetString("Nav_Home_AccessibilityStatement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installation.
         /// </summary>
         public static string Nav_Installation {

--- a/GCFoundation.Web/Resources/Navigation.fr.resx
+++ b/GCFoundation.Web/Resources/Navigation.fr.resx
@@ -261,4 +261,7 @@
   <data name="Nav_Template_Crud" xml:space="preserve">
     <value>Pages CRUD</value>
   </data>
+  <data name="Nav_Home_AccessibilityStatement" xml:space="preserve">
+    <value>Déclaration d'accessibilité</value>
+  </data>
 </root>

--- a/GCFoundation.Web/Resources/Navigation.resx
+++ b/GCFoundation.Web/Resources/Navigation.resx
@@ -261,4 +261,7 @@
   <data name="Nav_Template_Crud" xml:space="preserve">
     <value>CRUD Pages</value>
   </data>
+  <data name="Nav_Home_AccessibilityStatement" xml:space="preserve">
+    <value>Accessibility statement</value>
+  </data>
 </root>

--- a/GCFoundation.Web/appsettings.json
+++ b/GCFoundation.Web/appsettings.json
@@ -12,7 +12,7 @@
   "FoundationComponentsSettings": {
     "ApplicationNameFr": "GCFoundation",
     "ApplicationNameEn": "GCFoundation",
-    "ApplicationVersion": "1.0.4",
+    "ApplicationVersion": "1.0.5",
     "SupportLinkEn": "mailto:test@tbs-sct.gc.ca",
     "SupportLinkFr": "mailto:test@tbs-sct.gc.ca",
     "IncludeGCDSResources": true,
@@ -25,8 +25,8 @@
       {
         "LabelEn": "Accessibility statement",
         "LabelFr": "Déclaration d'accessibilité",
-        "LinkEn": "/en/home/accessibility-statement",
-        "LinkFr": "/fr/accueil/declaration-daccessibilite"
+        "LinkEn": "~/en/home/accessibility-statement",
+        "LinkFr": "~/fr/accueil/declaration-daccessibilite"
       },
       {
         "LabelEn": "Our GitHub repository",

--- a/GCFoundation.Web/navigation.xml
+++ b/GCFoundation.Web/navigation.xml
@@ -23,6 +23,7 @@
 
 			</Children>
 		</NavNode>
+    <NavNode key="accessibility-statement" controller="Home" action="AccessibilityStatement" area="" preservedRouteParameters="culture" text="Nav_AccessibilityStatement" />
     <NavNode key="installation" controller="Installation" action="Index" area="" preservedRouteParameters="culture" text="Nav_Installation" />
     <NavNode key="date-modified" controller="Installation" action="DateModified" area="" preservedRouteParameters="culture" text="Nav_Installation_DateModified" />
 		<NavNode key="global-resources" controller="Installation" action="GlobalResources" area="" preservedRouteParameters="culture" text="Nav_Installation_GlobalResources" />


### PR DESCRIPTION
1. Added the Accessibility statement to the sitemap.
2. Injected a UrlHelper to the FooterTagHelper to allow the use of relative pages and application relative pages (e.g. ~/en/home) in the global contextual links.
3. Created Unit Tests to test configuration of global footer links (absolute, relative and app-relative URLs).