### PR TITLE
Add StringSyntax attributes for better syntax highlighting for Visual Studio and Rider

### DIFF
--- a/GCFoundation.Common/Models/FooterLink.cs
+++ b/GCFoundation.Common/Models/FooterLink.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using GCFoundation.Common.Utilities;
 
 namespace GCFoundation.Common.Models
@@ -28,16 +29,19 @@ namespace GCFoundation.Common.Models
         /// The footer link URL, or the language-neutral fallback when
         /// <see cref="LinkEn"/> / <see cref="LinkFr"/> are used.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string? Link { get; set; }
 
         /// <summary>
         /// English URL when the UI culture is English. Falls back to <see cref="Link"/> when unset.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string? LinkEn { get; set; }
 
         /// <summary>
         /// French URL when the UI culture is French. Falls back to <see cref="Link"/> when unset.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string? LinkFr { get; set; }
 
         /// <summary>

--- a/GCFoundation.Components/Attributes/DateFormatAttribute.cs
+++ b/GCFoundation.Components/Attributes/DateFormatAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace GCFoundation.Components.Attributes
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GCFoundation.Components.Attributes
 {
     /// <summary>
     /// Specifies the format for a date property in a class.
@@ -10,13 +12,14 @@
         /// <summary>
         /// Gets the date format string.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
         public string Format { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DateFormatAttribute"/> class with the specified date format.
         /// </summary>
         /// <param name="format">The date format string to be applied to the property.</param>
-        public DateFormatAttribute(string format)
+        public DateFormatAttribute([StringSyntax(StringSyntaxAttribute.DateTimeFormat)]string format)
         {
             Format = format;
         }

--- a/GCFoundation.Components/Models/ErrorLink.cs
+++ b/GCFoundation.Components/Models/ErrorLink.cs
@@ -1,4 +1,6 @@
-﻿namespace GCFoundation.Components.Models
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GCFoundation.Components.Models
 {
     /// <summary>
     /// Represents an error link that contains a URL (Href) and an associated error message.
@@ -10,6 +12,7 @@
         /// This URL may be used to navigate to more information about the error.
         /// </summary>
         /// <value>A string representing the URL for the error link.</value>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string Href { get; set; }
 
         /// <summary>

--- a/GCFoundation.Components/Models/LanguageChooserModel.cs
+++ b/GCFoundation.Components/Models/LanguageChooserModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GCFoundation.Components.Models
 {
@@ -30,11 +31,13 @@ namespace GCFoundation.Components.Models
         /// <summary>
         /// Link to the term of service of the application in english
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string TermLinkEn { get; set; } = string.Empty;
 
         /// <summary>
         /// Link to the term of service of the application in french
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string TermLinkFr { get; set; } = string.Empty;
 
         /// <summary>

--- a/GCFoundation.Components/Models/StepperStep.cs
+++ b/GCFoundation.Components/Models/StepperStep.cs
@@ -1,4 +1,5 @@
-﻿using GCFoundation.Components.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using GCFoundation.Components.Enums;
 using System.Globalization;
 
 namespace GCFoundation.Components.Models
@@ -13,6 +14,7 @@ namespace GCFoundation.Components.Models
         /// Gets or sets the HTML for the FontAwesome icon to display when the step is completed.
         /// Example: "&lt;i class='fa fa-check'&gt;&lt;/i&gt;"
         /// </summary>
+        [StringSyntax("Html")]
         public string? CompletedIconHtml { get; set; }
 
         /// <summary>
@@ -24,6 +26,7 @@ namespace GCFoundation.Components.Models
         /// <summary>
         /// Gets or sets the HTML for the FontAwesome icon to display when the step is in progress.
         /// </summary>
+        [StringSyntax("Html")]
         public string? InProgressIconHtml { get; set; }
 
         /// <summary>
@@ -44,6 +47,7 @@ namespace GCFoundation.Components.Models
         /// <summary>
         /// Gets or sets the URL for navigation when the step is clicked.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
 #pragma warning disable CA1056 // URI-like properties should not be strings
         public string? LinkUrl { get; set; }
 #pragma warning restore CA1056 // URI-like properties should not be strings
@@ -51,11 +55,13 @@ namespace GCFoundation.Components.Models
         /// <summary>
         /// Gets or sets the HTML for the FontAwesome icon to display when the step hasn't been started.
         /// </summary>
+        [StringSyntax("Html")]
         public string? NotStartedIconHtml { get; set; }
 
         /// <summary>
         /// Gets or sets the text of the badge describing the status of the step.
         /// </summary>
+        [StringSyntax("Html")]
         public string? StatusBadgeLabel { get; set; }
 
         /// <summary>

--- a/GCFoundation.Components/Models/TableGridJs/TableGridJsConfiguration.cs
+++ b/GCFoundation.Components/Models/TableGridJs/TableGridJsConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace GCFoundation.Components.Models.TableGridJs
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GCFoundation.Components.Models.TableGridJs
 {
     /// <summary>
     /// Represents the configuration of a Grid.js table.
@@ -18,6 +20,7 @@
         /// <summary>
         /// (Optional) Url of the API endpoint that will be queried to return the data.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
 #pragma warning disable CA1056 // URI-like properties should not be strings
         public string? DataUrl { get; set; }
 #pragma warning restore CA1056 // URI-like properties should not be strings

--- a/GCFoundation.Components/Settings/GCFoundationUserLoginSettings.cs
+++ b/GCFoundation.Components/Settings/GCFoundationUserLoginSettings.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace GCFoundation.Components.Settings
 {
     /// <summary>
@@ -54,6 +56,7 @@ namespace GCFoundation.Components.Settings
         /// Default points to /authentication/logout.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "String is more suitable for configuration and view helpers")]
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string LogoutUrl { get; set; } = "/authentication/logout";
 
         /// <summary>
@@ -61,6 +64,7 @@ namespace GCFoundation.Components.Settings
         /// Default points to /authentication/login.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "String is more suitable for configuration and view helpers")]
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string LoginUrl { get; set; } = "/authentication/login";
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/FDCP/FdcpTableGridJsTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/FDCP/FdcpTableGridJsTagHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using GCFoundation.Components.Enums;
 using GCFoundation.Components.Models;
 using GCFoundation.Components.Models.TableGridJs;
@@ -40,6 +41,7 @@ namespace GCFoundation.Components.TagHelpers.FDCP
         /// </summary>
         [HtmlAttributeName("ajax-url")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "Endpoint path")] 
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string AjaxUrl { get; set; } = string.Empty;
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/BreadcrumbsItemTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/BreadcrumbsItemTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
 {
@@ -11,6 +12,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// The href (link) for the breadcrumb item.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string? Href { get; set; }
 
         /// <inheritdoc/>

--- a/GCFoundation.Components/TagHelpers/GCDS/CardTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/CardTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using GCFoundation.Components.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using GCFoundation.Components.Enums;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
@@ -23,6 +24,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the hyperlink URL that the card should link to.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string Href { get; set; }
 
         /// <summary>
@@ -43,6 +45,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the source URL for the image displayed on the card.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string? ImgSrc { get; set; }
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/CheckboxesTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/CheckboxesTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
 {
@@ -16,6 +17,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the options for the checkboxes, provided as a JSON string.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Json)]
         public required string Options { get; set; }
 
         /// <inheritdoc/>

--- a/GCFoundation.Components/TagHelpers/GCDS/HeaderTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/HeaderTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using GCFoundation.Components.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using GCFoundation.Components.Enums;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
@@ -13,16 +14,19 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the URL for the language toggle link. This is typically used for switching between languages.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string LangHref { get; set; }
 
         /// <summary>
         /// Gets or sets the URL for the "skip to content" link. This allows users to quickly jump to the main content of the page.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string SkipToHref { get; set; }
 
         /// <summary>
         /// Gets or sets a flag indicating whether the signature has a link. Default is <c>true</c>.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public bool SignatureHasLink { get; set; } = true;
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/LinkTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/LinkTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using GCFoundation.Components.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using GCFoundation.Components.Enums;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
@@ -27,6 +28,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the href attribute, which is the destination URL of the link.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string Href { get; set; } = "";
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/NavLinkTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/NavLinkTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
 {
@@ -12,6 +13,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// Gets or sets the URL that the navigation link points to.
         /// </summary>
         /// <value>The URL to navigate to when the link is clicked.</value>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string Href { get; set; }
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/PaginationTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/PaginationTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using GCFoundation.Components.Enums;
+﻿using System.Diagnostics.CodeAnalysis;
+using GCFoundation.Components.Enums;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
@@ -37,6 +38,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the hyperlink reference for the "Previous" button.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public string PreviousHref { get; set; } = "#previous";
 
         /// <summary>

--- a/GCFoundation.Components/TagHelpers/GCDS/RadiosTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/RadiosTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
 {
@@ -16,6 +17,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// <summary>
         /// Gets or sets the options for the radio buttons, provided as a JSON string.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Json)]
         public required string Options { get; set; }
 
         /// <inheritdoc/>

--- a/GCFoundation.Components/TagHelpers/GCDS/ToggleLanguageTagHelper.cs
+++ b/GCFoundation.Components/TagHelpers/GCDS/ToggleLanguageTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GCFoundation.Components.TagHelpers.GCDS
 {
@@ -13,6 +14,7 @@ namespace GCFoundation.Components.TagHelpers.GCDS
         /// Gets or sets the hyperlink reference for the language toggle.
         /// This should point to the alternate-language version of the current page.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.Uri)]
         public required string Href { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Before:
<img width="486" height="66" alt="no syntax highlighting for html string" src="https://github.com/user-attachments/assets/adbb257f-908a-405a-a5f2-12629d01ae3f" />

After:
<img width="486" height="66" alt="syntax highlighting for html string" src="https://github.com/user-attachments/assets/d9deae03-c1bc-406d-b229-bc4678dc9e8a" />
