### PR TITLE
update footerDisplay to allow compact or full FooterDisplayType

### DIFF
--- a/GCFoundation.Components/Views/Shared/_FoundationLayout.cshtml
+++ b/GCFoundation.Components/Views/Shared/_FoundationLayout.cshtml
@@ -190,6 +190,7 @@
         var controllerFooterContextualHeading = ViewData["FooterContextualHeading"] as string;
         var controllerFooterContextualLinks = ViewData["FooterContextualLinks"] as IEnumerable<FooterLink>;
         var controllerFooterSubLinks = ViewData["FooterSubLinks"] as IEnumerable<FooterLink>;
+        var footerDisplay = ViewData["FooterDisplay"] as FooterDisplayType? ?? FooterDisplayType.full;
         var footerContextualHeading = settings.Value.ApplicationName;
         var footerContextualLinks = new List<FooterLink>();
         var footerSubLinks = new List<FooterLink>();
@@ -216,7 +217,7 @@
             footerContextualHeading = controllerFooterContextualHeading;
         }
     }
-    <gcds-footer display="full" contextual-heading="@footerContextualHeading" contextual-links="@footerContextualLinks" sub-links="@footerSubLinks"></gcds-footer>
+    <gcds-footer display="@footerDisplay" contextual-heading="@footerContextualHeading" contextual-links="@footerContextualLinks" sub-links="@footerSubLinks"></gcds-footer>
 
     @* Render all modal in that section to make sure to block all content on the page *@
     @await RenderSectionAsync("Modals", required: false)


### PR DESCRIPTION
- Added ViewData["FooterDisplay"] support in _FoundationLayout.cshtml.

- Kept the shared layout fallback as FooterDisplayType.full.

- Configured GCFoundation.Web/Views/_ViewStart.cshtml to use FooterDisplayType.compact.

- Existing footer contextual heading and footer links continue to come from FoundationComponentsSettings and controller-level ViewData.