### PR TITLE
Allow hide canada link setting.

### DIFF
--- a/GCFoundation.Common/Settings/GCFoundationComponentsSettings.cs
+++ b/GCFoundation.Common/Settings/GCFoundationComponentsSettings.cs
@@ -121,6 +121,11 @@ namespace GCFoundation.Common.Settings
         /// </summary>
         public string VirtualDirectoryName { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Gets or sets whether to hide the default Canada.ca link in breadcrumbs.
+        /// </summary>
+        public bool HideCanadaLinkInBreadcrumbs { get; set; }
+
 
         /// <summary>
         /// Gets the list of additional CSS files to include globally.

--- a/GCFoundation.Common/Settings/GCFoundationComponentsSettings.cs
+++ b/GCFoundation.Common/Settings/GCFoundationComponentsSettings.cs
@@ -106,6 +106,11 @@ namespace GCFoundation.Common.Settings
         public string ApplicationVersion { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets whether to hide the default Canada.ca link in breadcrumbs.
+        /// </summary>
+        public bool HideCanadaLinkInBreadcrumbs { get; set; }
+
+        /// <summary>
         /// Gets or sets the support link (or mailto) for English users.
         /// </summary>
         public string SupportLinkEn { get; set; } = default!;
@@ -120,11 +125,6 @@ namespace GCFoundation.Common.Settings
         /// Example: "/myapp" or "myapp". Leave empty for root.
         /// </summary>
         public string VirtualDirectoryName { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets whether to hide the default Canada.ca link in breadcrumbs.
-        /// </summary>
-        public bool HideCanadaLinkInBreadcrumbs { get; set; }
 
 
         /// <summary>

--- a/GCFoundation.Components/Views/Shared/Components/Navigation/GCDSBreadcrumbs.cshtml
+++ b/GCFoundation.Components/Views/Shared/Components/Navigation/GCDSBreadcrumbs.cshtml
@@ -11,7 +11,7 @@
 @if (Model.CurrentNode != null && (Model.ParentChain.Count >= 1 || (Model.TailCrumbs != null && Model.TailCrumbs.Count > 0)))
 {
     <div slot="breadcrumb">
-        <gcds-breadcrumbs>
+        <gcds-breadcrumbs hide-canada-link="@settings.Value.HideCanadaLinkInBreadcrumbs">
             @foreach (var node in Model.ParentChain)
             {
                 if (!await Model.ShouldAllowView(node)) { continue; }

--- a/GCFoundation.Components/Views/Shared/Components/Navigation/GCDSBreadcrumbs.cshtml
+++ b/GCFoundation.Components/Views/Shared/Components/Navigation/GCDSBreadcrumbs.cshtml
@@ -3,9 +3,6 @@
 @using Microsoft.Extensions.Options
 ﻿@using cloudscribe.Web.Navigation
 @model NavigationViewModel
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, cloudscribe.Web.Navigation
-@using Microsoft.Extensions.Localization
 @inject IBreadcrumbsLocalizationService breadcrumbsLocalizationService
 @inject IOptions<GCFoundationComponentsSettings> settings;
 @if (Model.CurrentNode != null && (Model.ParentChain.Count >= 1 || (Model.TailCrumbs != null && Model.TailCrumbs.Count > 0)))

--- a/GCFoundation.Web/appsettings.json
+++ b/GCFoundation.Web/appsettings.json
@@ -17,6 +17,7 @@
     "SupportLinkFr": "mailto:test@tbs-sct.gc.ca",
     "IncludeGCDSResources": true,
     "IncludeFontAwesome": true,
+    "HideCanadaLinkInBreadcrumbs": false,
     "VirtualDirectoryName": "",
     "GlobalCssFiles": [
       "~/css/custom-styles.css"


### PR DESCRIPTION
Adds a framework-level configuration option to hide the default Canada.ca link in GCDS breadcrumbs.

- Added `HideCanadaLinkInBreadcrumbs` to `GCFoundationComponentsSettings`.

- Wired the shared `GCDSBreadcrumbs` view to pass the setting into `<gcds-breadcrumbs hide-canada-link="...">`.

- Added the option to the sample `appsettings.json` with the default value set to `false`, preserving existing behavior.